### PR TITLE
Autosign Session Bounce Fix

### DIFF
--- a/login-ZJU.js
+++ b/login-ZJU.js
@@ -5,15 +5,14 @@
  */
 var g={};function x(i,n){let t=new URL(i).host;return g[t]=g[t]||{},g[t]&&(n.headers={Cookie:Object.entries(g[t]).
 map(([e,o])=>`${e}=${o}`).join("; ")}),n.redirect="manual",fetch(i,n).then(e=>(e.headers.get("set-cookie")&&e.
-headers.getSetCookie().forEach(o=>{let[s,a]=o.split("=");g[t][s]=a}),e))}var c=x;var d=class{constructor(n){this.session="";this.firstTime=!0;this.zjuamInstance=n}async login(){return console.
-log("[COURSES] login begins"),c("https://courses.zju.edu.cn/user/index",{redirect:"manual"}).then(n=>{if(n.status==
-302)return c(n.headers.get("Location"),{redirect:"manual"});throw new Error("Fail at first load.")}).then(n=>{
-if(n.status==303)return c(n.headers.get("Location"),{redirect:"manual"});throw new Error("Fail at first load.")}).
-then(async n=>{if(n.status==303){let t=await this.zjuamInstance.loginSvc(decodeURIComponent(n.headers.get("Loc\
-ation").replace("https://zjuam.zju.edu.cn/cas/login?service=","")));return c(t,{redirect:"manual"})}else throw new Error(
-"Fail at first load.")}).then(n=>{if(n.status==302)return c(n.headers.get("Location"),{redirect:"manual"});throw new Error(
-"Fail at second load.")}).then(n=>{if(n.status==302)return console.log("[COURSES] Login success!"),this.session=
-n.headers.get("Set-Cookie").split(";")[0].split("=")[1],!0;throw new Error("Fail at login.")})}async fetch(n,t={}){
+headers.getSetCookie().forEach(o=>{let[s,a]=o.split("=");g[t][s]=a}),e))}var c=x;var d=class{constructor(n){this.session="";this.firstTime=!0;this.zjuamInstance=n}resetSession(){this.session="",this.firstTime=!0,delete g["courses.zju.edu.cn"]}async login(){return console.
+log("[COURSES] login begins"),c("https://courses.zju.edu.cn/user/index",{redirect:"manual"}).then(n=>{console.log("[COURSES] First load status:",n.status);if(n.status==
+302)return c(n.headers.get("Location"),{redirect:"manual"});throw new Error("Fail at first load (step 1).")}).then(n=>{
+console.log("[COURSES] Second load status:",n.status);if(n.status==303||n.status==302){let t=n.headers.get("Location");if(!t)throw new Error("Fail at first load (step 2, missing location).");return c(t,{redirect:"manual"});}throw new Error("Fail at first load (step 2).")}).
+then(async n=>{console.log("[COURSES] Third load status:",n.status);if(n.status==303||n.status==302){let t=n.headers.get("Location");if(!t)throw new Error("Fail at first load (step 3, missing location).");let e=n.status==303?decodeURIComponent(t.replace("https://zjuam.zju.edu.cn/cas/login?service=","")):t;let o=n.status==303?await this.zjuamInstance.loginSvc(e):t;console.log("[COURSES] Third load redirecting to:",o);return c(o,{redirect:"manual"})}else throw new Error(
+"Fail at first load (step 3).")}).then(n=>{console.log("[COURSES] Fourth load status:",n.status,"cookie?",!!n.headers.get("Set-Cookie"));if(n.status==302)return c(n.headers.get("Location"),{redirect:"manual"});if(n.headers.get("Set-Cookie"))return n;throw new Error(
+"Fail at second load.")}).then(n=>{if(n.status==302)return c(n.headers.get("Location"),{redirect:"manual"});if(n.headers.get("Set-Cookie"))return n;throw new Error(
+"Fail at second load.")}).then(n=>{console.log("[COURSES] Fifth load status:",n.status,"cookie?",!!n.headers.get("Set-Cookie"));return(async s=>{if(s.headers.get("Set-Cookie"))return this.session=s.headers.get("Set-Cookie").split(";")[0].split("=")[1],console.log("[COURSES] Login success!"),!0;if(s.status==302){let a=s.headers.get("Location");if(!a)throw new Error("Fail at login (missing redirect).");let h=await c(a,{redirect:"manual"});if(h.headers.get("Set-Cookie"))return this.session=h.headers.get("Set-Cookie").split(";")[0].split("=")[1],console.log("[COURSES] Login success!"),!0;throw new Error("Fail at login (no cookie after redirect).")}throw new Error("Fail at login.")})(n)})}async fetch(n,t={}){
 return this.firstTime&&(await this.login(),this.firstTime=!1),console.log("[COURSES] Fetching url:",n),t.headers=
 {...t?.headers,Cookie:"session="+this.session+";","X-Session-Id":this.session},fetch(n,t).then(e=>{if(e.headers.
 get("Set-Cookie")){let o=e.headers.get("Set-Cookie").split(";")[0].split("=")[1];o!==this.session&&(this.session=


### PR DESCRIPTION
# Autosign Session Bounce Fix

## Observed Symptoms (Occasionally met)

- `courses.zju/autosign.js` looped once, then threw `SyntaxError: Unexpected token '<'` because the second request to `https://courses.zju.edu.cn/api/radar/rollcalls` returned the Wisdomgarden SSO HTML page instead of JSON.
- After band-aiding the crash, the script still stalled: every few polls the Courses backend answered with `400 text/html`, the cached `session` cookie stopped working, and `COURSES.login()` failed when we tried to re-authenticate.

Here's the error message:

```
[Auto Sign-in](Req #2) No rollcalls found.
[COURSES] Fetching url: https://courses.zju.edu.cn/api/radar/rollcalls
<anonymous_script>:1
<html xmlns="http://www.w3.org/1999/xhtml">
^

SyntaxError: Unexpected token '<', "<html xmln"... is not valid JSON
    at JSON.parse (<anonymous>)
    at parseJSONFromBytes (node:internal/deps/undici/undici:5738:19)
    at successSteps (node:internal/deps/undici/undici:5719:27)
    at fullyReadBody (node:internal/deps/undici/undici:4609:9)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async consumeBody (node:internal/deps/undici/undici:5728:7)
    at async file:///Users/mohan/Documents/%E6%B1%82%E6%98%AF%E6%BD%AE/ZJU-live-better/courses.zju/autosign.js:38:5

Node.js v22.14.0
```

## Root Cause

The Courses cluster occasionally invalidates the current session immediately after a successful rollcall fetch. Our client blindly parsed responses as JSON, never reset its cookie jar, and assumed a rigid redirect chain when logging in. Once the server redirected us through CAS again we stayed stuck on the HTML page forever.

## Fix Strategy

1. **Poller hardening (`courses.zju/autosign.js`)**
   - Added a `fetchRollcalls()` helper that checks `response.ok` and `content-type`. Non‑JSON bodies now log their first 200 chars, trigger `courses.resetSession()` (or clear `firstTime`/`session`), and let the loop retry after the configured cooldown.
   - Wrapped the polling loop in `try/catch` so a single bad response only delays the next iteration.
   - Increased `CONFIG.coldDownTime` to 10 s so the script hammers the API less aggressively between forced logins.
2. **Session reset + resilient login (`login-ZJU.js`)**
   - Added `COURSES.resetSession()` to drop the cached `session` and purge host cookies for `courses.zju.edu.cn`.
   - Relaxed the redirect handling: each stage now logs its status code, accepts both `302` and `303`, tolerates cases where the session cookie arrives on an HTTP 200, and performs a final fallback redirect if needed before extracting the new cookie.
   - As a result, autosign can bail out of SSO loops by simply clearing its session and letting the login helper walk the new redirect shape.

## Validation

- `node courses.zju/autosign.js` (manual stop after ~80 s) now shows the expected pattern: occasional `400` HTML responses trigger a re-login, but the worker self-recovers and keeps polling (`Req #1` … `Req #19` in the sample run).
- `node --input-type=module` snippets that call `courses.login()` twice in a row now succeed because `resetSession()` plus the flexible redirect handling can always obtain a fresh cookie.

The API will still bounce us to SSO occasionally—that’s server-side throttling—but the script no longer crashes or gets stuck, so unattended sign-ins continue to work. This markdown file is ignored via `.gitignore` and meant only for the PR notes.