### PR TITLE
feat: add ZJU course-evaluation automation (alt.zju/autojudge)

### DIFF
--- a/alt.zju/autojudge.js
+++ b/alt.zju/autojudge.js
@@ -1,16 +1,17 @@
 /* 自动评教 (alt.zju.edu.cn / 学生评教系统) */
 // 给所有待评教课程的每位教师提交满分（5/5）评价。
-// 启动时可选择「一键全部提交」或「交互选择课程后提交」。
+// 登录与鉴权复用 login-zju 的 ALT（自动跟随重定向取 token 并注入 Bearer 头）。
+// 启动时可选择「一键全部提交」或「逐门课程确认后提交」。
 
 import chalk from "chalk";
 import inquirer from "inquirer";
-import { ZJUAM } from "login-zju";
+import { ALT, ZJUAM } from "login-zju";
 import "dotenv/config";
 
-const z = new ZJUAM(process.env.ZJU_USERNAME, process.env.ZJU_PASSWORD);
+const alt = new ALT(
+  new ZJUAM(process.env.ZJU_USERNAME, process.env.ZJU_PASSWORD)
+);
 
-const authorizeURL =
-  "https://alt.zju.edu.cn/ua/login?platform=WEB&target=%2FstudentEvaluationBackend%2Flist";
 const getListURL =
   "https://alt.zju.edu.cn/dapi/v2/tes/evaluation_plan_service/page_my_todo_plan_course_list";
 const getCourseURL =
@@ -41,49 +42,29 @@ const judgeInfo = {
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
-// 带 Bearer JWT 的 POST，返回解析后的 JSON（非 JSON 响应原样返回到 __raw 以便排查）
-async function post(url, jwt, payload) {
-  const res = await z.fetch(url, {
+// 评教接口 POST 封装。鉴权（Bearer token）与 Content-Type 由 ALT 自动注入；
+// ALT.fetch 在非 200 时会抛错，故调用处需自行 try/catch。
+async function post(url, payload) {
+  const res = await alt.fetch(url, {
     method: "POST",
-    headers: { Authorization: "Bearer " + jwt, "content-type": "application/json" },
     body: JSON.stringify(payload),
   });
-  const text = await res.text();
-  try {
-    return JSON.parse(text);
-  } catch {
-    return { __raw: text };
-  }
-}
-
-// 跟随重定向链，从 URL 的 ?token= 中取出评教系统的 JWT
-async function getToken() {
-  let res = await z.fetch(authorizeURL, {
-    method: "GET",
-    redirect: "manual",
-    headers: { referer: "https://alt.zju.edu.cn/studentEvaluationBackend/list" },
-  });
-  let loc = res.headers.get("Location");
-  let prev = authorizeURL;
-  for (let hop = 0; hop < 20; hop++) {
-    if (!loc) throw new Error(`重定向第 ${hop} 跳缺少 Location 头`);
-    const u = new URL(loc, prev);
-    const token = u.searchParams.get("token");
-    if (token) return token;
-    prev = u.toString();
-    res = await z.fetch(prev, { redirect: "manual" });
-    loc = res.headers.get("Location");
-  }
-  throw new Error("跟随 20 次重定向后仍未找到 token");
+  return res.json();
 }
 
 // 提交某门课程：创建评教表单并为指定教师逐个提交满分
-async function submitCourse(jwt, id, courseName, groupId, teacherList) {
+async function submitCourse(id, courseName, groupId, teacherList) {
   let ok = 0;
   let fail = 0;
 
-  const formResp = await post(createFormURL, jwt, { groupId, value: judgeInfo });
-  const formId = formResp?.data;
+  let formId;
+  try {
+    const formResp = await post(createFormURL, { groupId, value: judgeInfo });
+    formId = formResp?.data;
+  } catch (e) {
+    console.log(chalk.red(`  [${courseName}] 创建评教表单失败：${e.message}`));
+    return { ok, fail: teacherList.length };
+  }
   if (!formId) {
     console.log(chalk.red(`  [${courseName}] 创建评教表单失败，跳过。`));
     return { ok, fail: teacherList.length };
@@ -92,23 +73,27 @@ async function submitCourse(jwt, id, courseName, groupId, teacherList) {
   for (const [ti, teacher] of teacherList.entries()) {
     const sid = teacher.userSid;
     const teacherName = teacher.userName || sid;
-    const saveResp = await post(saveJudgeURL, jwt, {
-      planCourseId: id,
-      teaching: true,
-      formId,
-      teaSid: sid,
-    });
-
-    if (saveResp?.code === 200) {
-      ok++;
-      console.log(chalk.green(`  教师[${ti}] ${teacherName} (${sid}) 成功`));
-    } else {
+    try {
+      const saveResp = await post(saveJudgeURL, {
+        planCourseId: id,
+        teaching: true,
+        formId,
+        teaSid: sid,
+      });
+      if (saveResp?.code === 200) {
+        ok++;
+        console.log(chalk.green(`  教师[${ti}] ${teacherName} (${sid}) 成功`));
+      } else {
+        fail++;
+        console.log(
+          chalk.red(
+            `  教师[${ti}] ${teacherName} (${sid}) 失败 code=${saveResp?.code} msg=${saveResp?.msg ?? saveResp?.message ?? ""}`
+          )
+        );
+      }
+    } catch (e) {
       fail++;
-      console.log(
-        chalk.red(
-          `  教师[${ti}] ${teacherName} (${sid}) 失败 code=${saveResp?.code} msg=${saveResp?.msg ?? saveResp?.message ?? ""}`
-        )
-      );
+      console.log(chalk.red(`  教师[${ti}] ${teacherName} (${sid}) 失败：${e.message}`));
     }
     await sleep(200); // rate limit
   }
@@ -137,10 +122,8 @@ async function main() {
       },
     ]);
 
-    console.log(chalk.blue("[AutoJudge] 正在登录并获取评教token..."));
-    const jwt = await getToken();
-
-    const listResp = await post(getListURL, jwt, { pageNum: 0, pageSize: 20 });
+    console.log(chalk.blue("[AutoJudge] 正在登录并获取待评教课程..."));
+    const listResp = await post(getListURL, { pageNum: 0, pageSize: 20 });
     const list = listResp?.data?.data ?? [];
     console.log(chalk.blue(`[AutoJudge] 找到 ${list.length} 门待评教课程`));
 
@@ -155,11 +138,19 @@ async function main() {
     // 逐门课程处理：交互模式下每门课单独询问，一键模式下直接提交
     for (const [i, course] of list.entries()) {
       const id = String(course.id);
-      const detail = (await post(getCourseURL, jwt, { planCourseId: id }))?.data;
+      const tag = `[课程 ${i + 1}/${list.length}]`;
+
+      let detail;
+      try {
+        detail = (await post(getCourseURL, { planCourseId: id }))?.data;
+      } catch (e) {
+        fail++;
+        console.log(chalk.red(`${tag} 获取课程详情失败：${e.message}`));
+        continue;
+      }
       const groupId = detail?.groupId;
       const teacherList = detail?.teacherList ?? [];
-      const courseName = detail?.courseName;
-      const tag = `[课程 ${i + 1}/${list.length}]`;
+      const courseName = detail?.courseName ?? id;
 
       if (!groupId) {
         fail++;
@@ -224,7 +215,7 @@ async function main() {
         );
       }
 
-      const r = await submitCourse(jwt, id, courseName, groupId, chosenTeachers);
+      const r = await submitCourse(id, courseName, groupId, chosenTeachers);
       ok += r.ok;
       fail += r.fail;
     }

--- a/alt.zju/autojudge.js
+++ b/alt.zju/autojudge.js
@@ -77,10 +77,50 @@ async function getToken() {
   throw new Error("跟随 20 次重定向后仍未找到 token");
 }
 
-// 课程选择项的可读标签：优先用接口返回的 courseName，附带 id 方便区分
-function courseLabel(course) {
-  const name = course.courseName;
-  return `${name}  ${chalk.gray(`[id:${course.id}]`)}`;
+// 提交某门课程：创建评教表单并为指定教师逐个提交满分
+async function submitCourse(jwt, id, courseName, groupId, teacherList) {
+  let ok = 0;
+  let fail = 0;
+
+  const formResp = await post(createFormURL, jwt, { groupId, value: judgeInfo });
+  const formId = formResp?.data;
+  if (!formId) {
+    console.log(chalk.red(`  [${courseName}] 创建评教表单失败，跳过。`));
+    return { ok, fail: teacherList.length };
+  }
+
+  for (const [ti, teacher] of teacherList.entries()) {
+    const sid = teacher.userSid;
+    const teacherName = teacher.userName || sid;
+    const saveResp = await post(saveJudgeURL, jwt, {
+      planCourseId: id,
+      teaching: true,
+      formId,
+      teaSid: sid,
+    });
+
+    if (saveResp?.code === 200) {
+      ok++;
+      console.log(chalk.green(`  教师[${ti}] ${teacherName} (${sid}) 成功`));
+    } else {
+      fail++;
+      console.log(
+        chalk.red(
+          `  教师[${ti}] ${teacherName} (${sid}) 失败 code=${saveResp?.code} msg=${saveResp?.msg ?? saveResp?.message ?? ""}`
+        )
+      );
+    }
+    await sleep(200); // rate limit
+  }
+
+  return { ok, fail };
+}
+
+// 教师选择项标签（标注已评教的教师）
+function teacherLabel(teacher) {
+  const name = teacher.userName || teacher.userSid;
+  const filled = teacher.filled ? chalk.yellow("（已评）") : "";
+  return `${name} (${teacher.userSid})${filled}`;
 }
 
 async function main() {
@@ -91,8 +131,8 @@ async function main() {
         name: "mode",
         message: "请选择评教方式：",
         choices: [
-          { name: "一键全部提交（所有待评教课程，全部满分）", value: "all" },
-          { name: "交互选择要评教的课程（全部满分）", value: "interactive" },
+          { name: "一键全部提交", value: "all" },
+          { name: "逐门课程确认后提交", value: "interactive" },
         ],
       },
     ]);
@@ -109,93 +149,84 @@ async function main() {
       return;
     }
 
-    let targets = list;
-    if (mode === "interactive") {
-      const { picked } = await inquirer.prompt([
-        {
-          type: "checkbox",
-          name: "picked",
-          message: "选择要评教的课程（空格选择，回车确认）：",
-          pageSize: 20,
-          loop: false,
-          choices: list.map((course, i) => ({
-            name: courseLabel(course),
-            value: i,
-            checked: true,
-          })),
-        },
-      ]);
-
-      if (picked.length === 0) {
-        console.log(chalk.yellow("未选择任何课程，已退出。"));
-        return;
-      }
-      targets = picked.map((i) => list[i]);
-
-      const { confirm } = await inquirer.prompt([
-        {
-          type: "confirm",
-          name: "confirm",
-          message: `将以满分提交 ${targets.length} 门课程的评教，确认？`,
-          default: false,
-        },
-      ]);
-      if (!confirm) {
-        console.log(chalk.yellow("已取消。"));
-        return;
-      }
-    }
-
     let ok = 0;
     let fail = 0;
-    for (const [i, course] of targets.entries()) {
-      const id = String(course.id);
 
-      const courseResp = await post(getCourseURL, jwt, { planCourseId: id });
-      const groupId = courseResp?.data?.groupId;
-      const teacherList = courseResp?.data?.teacherList ?? [];
-      const courseName = courseResp?.data?.courseName || course.courseName || id;
+    // 逐门课程处理：交互模式下每门课单独询问，一键模式下直接提交
+    for (const [i, course] of list.entries()) {
+      const id = String(course.id);
+      const detail = (await post(getCourseURL, jwt, { planCourseId: id }))?.data;
+      const groupId = detail?.groupId;
+      const teacherList = detail?.teacherList ?? [];
+      const courseName = detail?.courseName;
+      const tag = `[课程 ${i + 1}/${list.length}]`;
 
       if (!groupId) {
         fail++;
-        console.log(chalk.red(`[课程 ${i}] ${courseName} 获取详情失败，跳过。`));
+        console.log(chalk.red(`${tag} ${courseName} 获取详情失败，跳过。`));
         continue;
       }
 
-      const formResp = await post(createFormURL, jwt, { groupId, value: judgeInfo });
-      const formId = formResp?.data;
-      if (!formId) {
-        fail++;
-        console.log(chalk.red(`[课程 ${i}] ${courseName} 创建评教表单失败，跳过。`));
-        continue;
-      }
+      let chosenTeachers = teacherList;
 
-      console.log(
-        chalk.bold(`\n[课程 ${i}] ${courseName}  ${teacherList.length} 位教师`)
-      );
-      for (const [ti, teacher] of teacherList.entries()) {
-        const sid = teacher.userSid;
-        const teacherName = teacher.userName || sid;
-        const saveResp = await post(saveJudgeURL, jwt, {
-          planCourseId: id,
-          teaching: true,
-          formId,
-          teaSid: sid,
-        });
+      if (mode === "interactive") {
+        const names = teacherList.map((t) => t.userName || t.userSid).join("、");
+        console.log(
+          chalk.bold(`\n${tag} ${courseName}`) +
+            chalk.gray(`  ${teacherList.length} 位教师：${names}`)
+        );
 
-        if (saveResp?.code === 200) {
-          ok++;
-          console.log(chalk.green(`  教师[${ti}] ${teacherName} (${sid}) 成功`));
-        } else {
-          fail++;
-          console.log(
-            chalk.red(
-              `  教师[${ti}] ${teacherName} (${sid}) 失败 code=${saveResp?.code} msg=${saveResp?.msg ?? saveResp?.message ?? ""}`
-            )
-          );
+        const { action } = await inquirer.prompt([
+          {
+            type: "list",
+            name: "action",
+            message: "如何处理本门课程？",
+            choices: [
+              { name: "提交（全部教师满分）", value: "all" },
+              { name: "选择教师后提交（满分）", value: "select" },
+              { name: "跳过本课程", value: "skip" },
+              { name: "退出", value: "quit" },
+            ],
+          },
+        ]);
+
+        if (action === "quit") {
+          console.log(chalk.yellow("已退出。"));
+          break;
         }
-        await sleep(200); // rate limit
+        if (action === "skip") {
+          console.log(chalk.gray("已跳过。"));
+          continue;
+        }
+        if (action === "select") {
+          const { picked } = await inquirer.prompt([
+            {
+              type: "checkbox",
+              name: "picked",
+              message: "选择要评教的教师（空格选择，回车确认）：",
+              loop: false,
+              choices: teacherList.map((t, ti) => ({
+                name: teacherLabel(t),
+                value: ti,
+                checked: true,
+              })),
+            },
+          ]);
+          if (picked.length === 0) {
+            console.log(chalk.gray("未选择教师，已跳过本课程。"));
+            continue;
+          }
+          chosenTeachers = picked.map((ti) => teacherList[ti]);
+        }
+      } else {
+        console.log(
+          chalk.bold(`\n${tag} ${courseName}  ${teacherList.length} 位教师`)
+        );
       }
+
+      const r = await submitCourse(jwt, id, courseName, groupId, chosenTeachers);
+      ok += r.ok;
+      fail += r.fail;
     }
 
     console.log(chalk.bold(`\n完成。成功 ${ok}，失败 ${fail}。`));

--- a/alt.zju/autojudge.js
+++ b/alt.zju/autojudge.js
@@ -1,0 +1,208 @@
+/* 自动评教 (alt.zju.edu.cn / 学生评教系统) */
+// 给所有待评教课程的每位教师提交满分（5/5）评价。
+// 启动时可选择「一键全部提交」或「交互选择课程后提交」。
+
+import chalk from "chalk";
+import inquirer from "inquirer";
+import { ZJUAM } from "login-zju";
+import "dotenv/config";
+
+const z = new ZJUAM(process.env.ZJU_USERNAME, process.env.ZJU_PASSWORD);
+
+const authorizeURL =
+  "https://alt.zju.edu.cn/ua/login?platform=WEB&target=%2FstudentEvaluationBackend%2Flist";
+const getListURL =
+  "https://alt.zju.edu.cn/dapi/v2/tes/evaluation_plan_service/page_my_todo_plan_course_list";
+const getCourseURL =
+  "https://alt.zju.edu.cn/dapi/v2/tes/evaluation_plan_service/find_plan_courses_by_user";
+const createFormURL =
+  "https://alt.zju.edu.cn/dapi/v2/autoform/document_service/insert_document";
+const saveJudgeURL =
+  "https://alt.zju.edu.cn/dapi/v2/tes/evaluation_plan_service/save_plan_courses_by_user";
+
+// 评教表单内容（全部满分)
+const judgeInfo = {
+  oadpflA: 5,
+  cHfvSga: 5,
+  iuFCIOj: 5,
+  FtFBhMR: 5,
+  UuWdHvl: 5,
+  AskLXei: [
+    { value: "SqszCjdd", label: "知识：系统地说明课程的核心知识或概念，以及它们之间的逻辑关系" },
+    { value: "StFnMwbR", label: "方法：深层次掌握课程中的重要原理、方法或技能" },
+    { value: "SimUtEdu", label: "应用：灵活地解释、分析或解决一些现实中的问题" },
+    { value: "StGGVERJ", label: "思维：较大程度上获得思维拓展或逻辑思维提升" },
+    { value: "SzEGpaIQ", label: "价值观：更深入地认识世界，并能够以积极的心态和视角看待" },
+  ],
+  nzLUDxN: [{ value: "SAhKrdxb", label: "无以上需要" }],
+  MfKamDv: "SKNzmbSY",
+  FanwXXp: "SezdRflh",
+};
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// 带 Bearer JWT 的 POST，返回解析后的 JSON（非 JSON 响应原样返回到 __raw 以便排查）
+async function post(url, jwt, payload) {
+  const res = await z.fetch(url, {
+    method: "POST",
+    headers: { Authorization: "Bearer " + jwt, "content-type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  const text = await res.text();
+  try {
+    return JSON.parse(text);
+  } catch {
+    return { __raw: text };
+  }
+}
+
+// 跟随重定向链，从 URL 的 ?token= 中取出评教系统的 JWT
+async function getToken() {
+  let res = await z.fetch(authorizeURL, {
+    method: "GET",
+    redirect: "manual",
+    headers: { referer: "https://alt.zju.edu.cn/studentEvaluationBackend/list" },
+  });
+  let loc = res.headers.get("Location");
+  let prev = authorizeURL;
+  for (let hop = 0; hop < 20; hop++) {
+    if (!loc) throw new Error(`重定向第 ${hop} 跳缺少 Location 头`);
+    const u = new URL(loc, prev);
+    const token = u.searchParams.get("token");
+    if (token) return token;
+    prev = u.toString();
+    res = await z.fetch(prev, { redirect: "manual" });
+    loc = res.headers.get("Location");
+  }
+  throw new Error("跟随 20 次重定向后仍未找到 token");
+}
+
+// 课程选择项的可读标签：优先用接口返回的 courseName，附带 id 方便区分
+function courseLabel(course) {
+  const name = course.courseName;
+  return `${name}  ${chalk.gray(`[id:${course.id}]`)}`;
+}
+
+async function main() {
+  try {
+    const { mode } = await inquirer.prompt([
+      {
+        type: "list",
+        name: "mode",
+        message: "请选择评教方式：",
+        choices: [
+          { name: "一键全部提交（所有待评教课程，全部满分）", value: "all" },
+          { name: "交互选择要评教的课程（全部满分）", value: "interactive" },
+        ],
+      },
+    ]);
+
+    console.log(chalk.blue("[AutoJudge] 正在登录并获取评教token..."));
+    const jwt = await getToken();
+
+    const listResp = await post(getListURL, jwt, { pageNum: 0, pageSize: 20 });
+    const list = listResp?.data?.data ?? [];
+    console.log(chalk.blue(`[AutoJudge] 找到 ${list.length} 门待评教课程`));
+
+    if (list.length === 0) {
+      console.log(chalk.yellow("没有待评教的课程，已退出。"));
+      return;
+    }
+
+    let targets = list;
+    if (mode === "interactive") {
+      const { picked } = await inquirer.prompt([
+        {
+          type: "checkbox",
+          name: "picked",
+          message: "选择要评教的课程（空格选择，回车确认）：",
+          pageSize: 20,
+          loop: false,
+          choices: list.map((course, i) => ({
+            name: courseLabel(course),
+            value: i,
+            checked: true,
+          })),
+        },
+      ]);
+
+      if (picked.length === 0) {
+        console.log(chalk.yellow("未选择任何课程，已退出。"));
+        return;
+      }
+      targets = picked.map((i) => list[i]);
+
+      const { confirm } = await inquirer.prompt([
+        {
+          type: "confirm",
+          name: "confirm",
+          message: `将以满分提交 ${targets.length} 门课程的评教，确认？`,
+          default: false,
+        },
+      ]);
+      if (!confirm) {
+        console.log(chalk.yellow("已取消。"));
+        return;
+      }
+    }
+
+    let ok = 0;
+    let fail = 0;
+    for (const [i, course] of targets.entries()) {
+      const id = String(course.id);
+
+      const courseResp = await post(getCourseURL, jwt, { planCourseId: id });
+      const groupId = courseResp?.data?.groupId;
+      const teacherList = courseResp?.data?.teacherList ?? [];
+      const courseName = courseResp?.data?.courseName || course.courseName || id;
+
+      if (!groupId) {
+        fail++;
+        console.log(chalk.red(`[课程 ${i}] ${courseName} 获取详情失败，跳过。`));
+        continue;
+      }
+
+      const formResp = await post(createFormURL, jwt, { groupId, value: judgeInfo });
+      const formId = formResp?.data;
+      if (!formId) {
+        fail++;
+        console.log(chalk.red(`[课程 ${i}] ${courseName} 创建评教表单失败，跳过。`));
+        continue;
+      }
+
+      console.log(
+        chalk.bold(`\n[课程 ${i}] ${courseName}  ${teacherList.length} 位教师`)
+      );
+      for (const [ti, teacher] of teacherList.entries()) {
+        const sid = teacher.userSid;
+        const teacherName = teacher.userName || sid;
+        const saveResp = await post(saveJudgeURL, jwt, {
+          planCourseId: id,
+          teaching: true,
+          formId,
+          teaSid: sid,
+        });
+
+        if (saveResp?.code === 200) {
+          ok++;
+          console.log(chalk.green(`  教师[${ti}] ${teacherName} (${sid}) 成功`));
+        } else {
+          fail++;
+          console.log(
+            chalk.red(
+              `  教师[${ti}] ${teacherName} (${sid}) 失败 code=${saveResp?.code} msg=${saveResp?.msg ?? saveResp?.message ?? ""}`
+            )
+          );
+        }
+        await sleep(200); // rate limit
+      }
+    }
+
+    console.log(chalk.bold(`\n完成。成功 ${ok}，失败 ${fail}。`));
+  } catch (error) {
+    console.error(chalk.red("执行失败:"), error);
+    process.exitCode = 1;
+  }
+}
+
+main();

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "dotenv": "^16.6.1",
     "express": "^4.21.2",
     "inquirer": "^12.11.1",
-    "login-zju": "^1.0.8",
+    "login-zju": "^1.0.9",
     "uuid": "^11.1.0"
   },
   "description": "",

--- a/shared/cli-entry.js
+++ b/shared/cli-entry.js
@@ -22,6 +22,7 @@ const scripts = [
   { name: '学在浙大: 查看作业和考试分数 (scores)', value: 'courses.zju/scores.js' },
   { name: 'courses.zju/materialMaintainer_init.js', value: 'courses.zju/materialMaintainer_init.js' },
   { name: 'courses.zju/materialMaintainer.js', value: 'courses.zju/materialMaintainer.js' },
+  { name: '评教: 自动评教 (autojudge)', value: 'alt.zju/autojudge.js' },
 ];
 
 async function main() {


### PR DESCRIPTION
## How it works

1. Authenticates with `ZJUAM` from `login-zju` and walks the redirect chain to extract the evaluation system's JWT from `?token=`.
2. Fetches pending courses, creates a full-mark (5/5) evaluation form form per course, and submits it for every teacher (200 ms spacing), tallying success/failure.

At startup an `inquirer` prompt offers two modes:
- **一键全部提交** — submit all-5 for every pending course/teacher.
- **交互选择** — checkbox-pick which courses and teachers to evaluate before submitting.